### PR TITLE
Fix: zip can contain directories and files at the root

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,7 @@
 
 ## 1.36.1 (2024-xx-xx)
 
+- FIX: Fix `files.extract_file` when there is a file in the root of the zip archive ([#11](https://github.com/sertit/sertit-utils/pull/11))
 - FIX: Fix `geometry.nearest_neighbors` when k is bigger than the number of candidates
 - DOC: Update some examples in documentation
 

--- a/sertit/files.py
+++ b/sertit/files.py
@@ -200,7 +200,8 @@ def extract_file(
     if file_path.suffix == ".zip":
         # Manage the case with several directories inside one zipfile
         arch = zipfile.ZipFile(file_path, "r")
-        extr_names = list({p.split("/")[0] for p in arch.namelist()})
+        # extr_names contains only directory names
+        extr_names = list({p.split("/")[0] for p in arch.namelist() if "/" in p})
     elif file_path.suffix == ".tar" or file_path.suffixes == [".tar", ".gz"]:
         # Tar files have no subdirectories, so create one
         extr_names = [path.get_filename(file_path)]

--- a/sertit/files.py
+++ b/sertit/files.py
@@ -200,7 +200,9 @@ def extract_file(
     if file_path.suffix == ".zip":
         # Manage the case with several directories inside one zipfile
         arch = zipfile.ZipFile(file_path, "r")
-        # extr_names contains only directory names
+
+        # zipfile.namelist returns the relative path of the file names in the archive
+        # if a file is in the root of the archive, there is no "/", so it should not be included
         extr_names = list({p.split("/")[0] for p in arch.namelist() if "/" in p})
     elif file_path.suffix == ".tar" or file_path.suffixes == [".tar", ".gz"]:
         # Tar files have no subdirectories, so create one


### PR DESCRIPTION
Choose a zip with a file XXX and a directory at the root of the archive.
Try to use extract_file method, you get this error:
[Errno 21] Is a directory: 'XXX'
We should not consider the file as a directory.

