### PR TITLE
Fix #160: make get_archived_path function case insensitive by default

### DIFF
--- a/sertit/path.py
+++ b/sertit/path.py
@@ -182,7 +182,10 @@ def get_archived_file_list(archive_path: AnyPathStrType) -> list:
 
 
 def get_archived_path(
-    archive_path: AnyPathStrType, file_regex: str, as_list: bool = False
+    archive_path: AnyPathStrType,
+    file_regex: str,
+    as_list: bool = False,
+    case_sensitive: bool = False,
 ) -> Union[list, AnyPathType]:
     """
     Get archived file path from inside the archive.
@@ -196,6 +199,7 @@ def get_archived_path(
         archive_path (AnyPathStrType): Archive path
         file_regex (str): File regex (used by re) as it can be found in the getmembers() list
         as_list (bool): If true, returns a list (including all found files). If false, returns only the first match
+        case_sensitive (bool): If true, the regex is case-sensitive.
 
     Returns:
         Union[list, str]: Path from inside the zipfile
@@ -211,7 +215,11 @@ def get_archived_path(
     file_list = get_archived_file_list(archive_path)
 
     # Search for file
-    regex = re.compile(file_regex)
+    regex = (
+        re.compile(file_regex)
+        if case_sensitive
+        else re.compile(file_regex, re.IGNORECASE)
+    )
     archived_band_paths = list(filter(regex.match, file_list))
     if not archived_band_paths:
         raise FileNotFoundError(


### PR DESCRIPTION
### Your checklist for this pull request
Please review the [guidelines for contributing](../CONTRIBUTING.md) to this repository.

- [ ] Check the commit's or even all commits' message styles matches our requested structure.
- [ ] Check your code additions will fail neither code linting checks nor unit test.

### Description
Please describe your pull request.

### Further comments
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...

Thank you!
